### PR TITLE
PRマージ時のX自動投稿ワークフローを追加

### DIFF
--- a/.github/workflows/post-to-x.yml
+++ b/.github/workflows/post-to-x.yml
@@ -10,10 +10,10 @@ on:
 jobs:
   post-to-x:
     runs-on: ubuntu-latest
-    # マージされたPRのみX投稿を実行する（skip-notificationラベルがついていない場合）
+    # マージされたPRのみX投稿を実行する（trigger-notificationラベルがついている場合）
     if: |
       github.event.pull_request.merged == true &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-notification')
+      contains(github.event.pull_request.labels.*.name, 'trigger-notification')
     steps:
       - name: Post X
         run: |

--- a/.github/workflows/post-to-x.yml
+++ b/.github/workflows/post-to-x.yml
@@ -1,0 +1,22 @@
+name: Post PR Info to X
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [shugiin-2026]
+    paths:
+      - '[0-9]*.md'
+
+jobs:
+  post-to-x:
+    runs-on: ubuntu-latest
+    # マージされたPRのみX投稿を実行する（skip-notificationラベルがついていない場合）
+    if: |
+      github.event.pull_request.merged == true &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-notification')
+    steps:
+      - name: Post X
+        run: |
+          curl -v -H 'Authorization: Bearer ${{ secrets.MANIFESTO_NOTIFY_API_TOKEN }}' \
+            --json '{"githubPrUrl": "${{ github.event.pull_request.html_url }}"}' \
+            ${{ secrets.MANIFESTO_NOTIFY_ENDPOINT }}


### PR DESCRIPTION
## Summary
- PRがマージされた際に自動でXに投稿するGitHub Actionsワークフローを追加
- `shugiin-2026`ブランチへのマージ、かつ`[0-9]*.md`ファイルの変更時のみ発火
- `skip-notification`ラベルをつけることで投稿をスキップ可能

## Test plan
- [ ] Secretsが設定されていることを確認（`MANIFESTO_NOTIFY_API_TOKEN`, `MANIFESTO_NOTIFY_ENDPOINT`）
- [ ] テスト用PRをマージして動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)